### PR TITLE
ensure cimlib read-compatibility of VTUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ To agilitate the use through the command line you can source `meshio/tools/bash_
 source meshio/tools/bash_meshio_rc.sh
 ```
 
-or by adding the source call directly to your `.bashrc` in Linux.
+or by adding the source call directly to the `bin/activate` file in meshio's virtual environment.
 
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ You can also install meshio from [Anaconda](https://anaconda.org/conda-forge/mes
 conda install -c conda-forge meshio
 ```
 
+To agilitate the use through the command line you can source `meshio/tools/bash_meshio_rc.sh`. This will load in the commands `ascii`, `binary`, `compress`, `convert`, `decompress` and `info`. Sourcing can be done manually through
+
+```
+source meshio/tools/bash_meshio_rc.sh
+```
+
+or by adding the source call directly to your `.bashrc` in Linux.
+
+
 ### Testing
 
 To run the meshio unit tests, check out this repository and type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "importlib_metadata; python_version<'3.8'",
   "numpy>=1.20.0",
   "rich",
+  "psutil",
 ]
 
 [project.optional-dependencies]

--- a/src/meshio/_cli/_ascii.py
+++ b/src/meshio/_cli/_ascii.py
@@ -15,6 +15,20 @@ def add_args(parser):
         help="input file format",
         default=None,
     )
+    parser.add_argument(
+        "--precision",
+        "-p",
+        type=int,
+        help="number of decimal places",
+        default=None,
+    )
+    parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="force overwrite",
+        default=False,
+    )
 
     parser.add_argument("infile", type=str, nargs="*", help="mesh file to convert")
 
@@ -34,10 +48,11 @@ def ascii(args):
         size = os.stat(file).st_size
         print(f"File size before: {size / 1024 ** 2:.2f} MB")
 
-        if fmt == "vtu":
-            if vtu.check_data_format(file, "ascii"):
-                print(f"{file} is already ascii")
-                return
+        if not args.force:
+            if fmt == "vtu":
+                if vtu.check_data_format(file, "ascii"):
+                    print(f"{file} is already ascii")
+                    return
 
         mesh = read(file, file_format=args.input_format)
 
@@ -46,27 +61,29 @@ def ascii(args):
 
         # write it out
         if fmt == "ansys":
-            ansys.write(file, mesh, binary=False)
+            ansys.write("a" + file, mesh, binary=False)
         elif fmt == "flac3d":
-            flac3d.write(file, mesh, binary=False)
+            flac3d.write("a" + file, mesh, binary=False)
         elif fmt == "gmsh":
-            gmsh.write(file, mesh, binary=False)
+            gmsh.write("a" + file, mesh, binary=False)
         elif fmt == "mdpa":
-            mdpa.write(file, mesh, binary=False)
+            mdpa.write("a" + file, mesh, binary=False)
         elif fmt == "ply":
-            ply.write(file, mesh, binary=False)
+            ply.write("a" + file, mesh, binary=False)
         elif fmt == "stl":
-            stl.write(file, mesh, binary=False)
+            stl.write("a" + file, mesh, binary=False)
         elif fmt == "vtk":
-            vtk.write(file, mesh, binary=False)
+            vtk.write("a" + file, mesh, binary=False)
         elif fmt == "vtu":
-            vtu.write(file, mesh, binary=False)
+            vtu.write("a" + file, mesh, binary=False, precision=args.precision)
         elif fmt == "xdmf":
-            xdmf.write(file, mesh, data_format="XML")
+            xdmf.write("a" + file, mesh, data_format="XML")
         else:
             error(f"Don't know how to convert {file} to ASCII format.")
             return 1
 
+        os.remove(file)
+        os.rename("a" + file, file)
         size = os.stat(file).st_size
         print(f"File size after: {size / 1024 ** 2:.2f} MB")
         return 0

--- a/src/meshio/_cli/_ascii.py
+++ b/src/meshio/_cli/_ascii.py
@@ -16,7 +16,7 @@ def add_args(parser):
         default=None,
     )
 
-    parser.add_argument("infile", type=str, nargs='*', help="mesh file to convert")
+    parser.add_argument("infile", type=str, nargs="*", help="mesh file to convert")
 
 
 def ascii(args):
@@ -33,6 +33,12 @@ def ascii(args):
 
         size = os.stat(file).st_size
         print(f"File size before: {size / 1024 ** 2:.2f} MB")
+
+        if fmt == "vtu":
+            if vtu.check_data_format(file, "ascii"):
+                print(f"{file} is already ascii")
+                return
+
         mesh = read(file, file_format=args.input_format)
 
         # # Some converters (like VTK) require `points` to be contiguous.

--- a/src/meshio/_cli/_binary.py
+++ b/src/meshio/_cli/_binary.py
@@ -20,11 +20,17 @@ def add_args(parser):
 
 
 def parallel_func(inputs) -> None:
-    
+
     file, input_format = inputs
 
     size = os.stat(file).st_size
     print(f"File size before: {size / 1024 ** 2:.2f} MB")
+
+    if input_format == "vtu":
+        if vtu.check_data_format(file, "binary"):
+            print(f"{file} is already binary")
+            return
+
     mesh = read(file, file_format=input_format)
 
     # # Some converters (like VTK) require `points` to be contiguous.
@@ -72,9 +78,7 @@ def binary(args):
         if args.input_format:
             input_format = [args.input_format] * len(args.infile)
         else:
-            input_formats = [
-                _filetypes_from_path(pathlib.Path(file))[0] for file in args.infile
-            ]
+            input_formats = [_filetypes_from_path(pathlib.Path(file))[0] for file in args.infile]
 
         flexible_args = list(zip(args.infile, input_formats))
 

--- a/src/meshio/_cli/_binary.py
+++ b/src/meshio/_cli/_binary.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import multiprocessing as mp
 from .. import ansys, flac3d, gmsh, mdpa, ply, stl, vtk, vtu, xdmf
-from .._helpers import _filetypes_from_path, read, reader_map
+from .._helpers import _filetypes_from_path, read, reader_map, estimate_optimal_processes
 
 
 def add_args(parser):
@@ -82,5 +82,8 @@ def binary(args):
 
         flexible_args = list(zip(args.infile, input_formats))
 
-        with mp.Pool(processes=16) as pool:
+        num_processes = estimate_optimal_processes(args.infile)
+        print(f"Using {num_processes} processes...")
+
+        with mp.Pool(processes=num_processes) as pool:
             pool.map(parallel_func, flexible_args)

--- a/src/meshio/_cli/_binary.py
+++ b/src/meshio/_cli/_binary.py
@@ -1,11 +1,12 @@
 import os
 import pathlib
 import multiprocessing as mp
+from argparse import ArgumentParser
 from .. import ansys, flac3d, gmsh, mdpa, ply, stl, vtk, vtu, xdmf
 from .._helpers import _filetypes_from_path, read, reader_map, estimate_optimal_processes
 
 
-def add_args(parser):
+def add_args(parser: ArgumentParser):
 
     parser.add_argument(
         "--input-format",
@@ -63,7 +64,7 @@ def parallel_func(inputs) -> None:
     print(f"File size after: {size / 1024 ** 2:.2f} MB")
 
 
-def binary(args):
+def binary(args: ArgumentParser):
     if not isinstance(args.infile, list):
 
         if args.input_format:

--- a/src/meshio/_common.py
+++ b/src/meshio/_common.py
@@ -101,9 +101,14 @@ def write_xml(filename, root):
     tree.write(filename)
 
 
-def _pick_first_int_data(data):
+def _pick_first_int_data(data, except_data=None):
+    if except_data is None:
+        except_data = []
     # pick out material
     keys = list(data.keys())
+    for key in except_data:
+        if key in keys:
+            keys.remove(key)
     candidate_keys = []
     for key in keys:
         # works for point_data and cell_data

--- a/src/meshio/_cxml/etree.py
+++ b/src/meshio/_cxml/etree.py
@@ -28,7 +28,10 @@ class Element:
             kw_list.remove('Name="Points"')
         # Paraview reads connectivities as 1 component
         if 'Name="connectivity"' in kw_list:
-            kw_list.remove('NumberOfComponents="3"')
+            for n in ('NumberOfComponents="3"', 'NumberOfComponents="4"'):
+                if n in kw_list:
+                    kw_list.remove(n)
+                    break
         f.write("<{}>\n".format(" ".join([self.name] + kw_list)))
         if self.text:
             f.write(self.text)

--- a/src/meshio/_cxml/etree.py
+++ b/src/meshio/_cxml/etree.py
@@ -23,6 +23,12 @@ class Element:
 
     def write(self, f):
         kw_list = [f'{key}="{value}"' for key, value in self.attrib.items()]
+        # cimlib does not read Points if Name kw is present
+        if 'Name="Points"' in kw_list:
+            kw_list.remove('Name="Points"')
+        # Paraview reads connectivities as 1 component
+        if 'Name="connectivity"' in kw_list:
+            kw_list.remove('NumberOfComponents="3"')
         f.write("<{}>\n".format(" ".join([self.name] + kw_list)))
         if self.text:
             f.write(self.text)

--- a/src/meshio/_helpers.py
+++ b/src/meshio/_helpers.py
@@ -19,7 +19,9 @@ reader_map = {}
 _writer_map = {}
 
 
-def register_format(format_name: str, extensions: list[str], reader, writer_map) -> None:
+def register_format(
+    format_name: str, extensions: list[str], reader, writer_map
+) -> None:
     for ext in extensions:
         if ext not in extension_to_filetypes:
             extension_to_filetypes[ext] = []
@@ -59,7 +61,11 @@ def _filetypes_from_path(path: Path) -> list[str]:
 
 
 def get_available_cores():
-    return min(mp.cpu_count(), len(os.sched_getaffinity(0))) if hasattr(os, "sched_getaffinity") else mp.cpu_count()
+    return (
+        min(mp.cpu_count(), len(os.sched_getaffinity(0)))
+        if hasattr(os, "sched_getaffinity")
+        else mp.cpu_count()
+    )
 
 
 def get_available_memory():
@@ -97,7 +103,8 @@ def _read_buffer(filename, file_format: str | None, **kwargs):
         raise ReadError("File format must be given if buffer is used")
     if file_format == "tetgen":
         raise ReadError(
-            "tetgen format is spread across multiple files " "and so cannot be read from a buffer"
+            "tetgen format is spread across multiple files "
+            "and so cannot be read from a buffer"
         )
     if file_format not in reader_map:
         raise ReadError(f"Unknown file format '{file_format}'")

--- a/src/meshio/_mesh.py
+++ b/src/meshio/_mesh.py
@@ -348,9 +348,7 @@ class Mesh:
                     try:
                         arr[cc] = i
                     except:
-                        warn(
-                            f"Cell sets are ill-defined : {cc} out of range {len(arr)}"
-                        )
+                        warn(f"Cell sets are ill-defined : {cc} out of range {len(arr)}")
                         continue
                 intfun.append(arr)
 
@@ -445,3 +443,34 @@ class Mesh:
 
         # remove the cell data
         del self.point_data[key]
+
+
+# This class is used to store mesh data without any cell data.
+# Useful for conversion to xdmf with one mesh and multiple time steps.
+class MeshOnlyFields:
+    def __init__(
+        self,
+        point_data: dict[str, ArrayLike] | None = None,
+        cell_data: dict[str, list[ArrayLike]] | None = None,
+        user_data: dict[str, list[ArrayLike]] | None = None,
+        field_data=None,
+        point_sets: dict[str, ArrayLike] | None = None,
+        cell_sets: dict[str, list[ArrayLike]] | None = None,
+        gmsh_periodic=None,
+        info=None,
+    ):
+        self.points = np.array([])
+        self.cells = []
+
+        self.point_data = {} if point_data is None else point_data
+        self.cell_data = {} if cell_data is None else cell_data
+        self.user_data = {} if user_data is None else user_data
+        self.field_data = {} if field_data is None else field_data
+        self.point_sets = {} if point_sets is None else point_sets
+        self.cell_sets = {} if cell_sets is None else cell_sets
+        self.gmsh_periodic = gmsh_periodic
+        self.info = info
+
+        for key, data in self.cell_data.items():
+            for k in range(len(data)):
+                data[k] = np.asarray(data[k])

--- a/src/meshio/_mesh.py
+++ b/src/meshio/_mesh.py
@@ -93,7 +93,9 @@ class CellBlock:
         self.data = data
 
         if cell_type not in topological_dimension:
-            raise ValueError(f"Unknown cell type '{cell_type}'. Choose from {topological_dimension.keys()}")
+            raise ValueError(
+                f"Unknown cell type '{cell_type}'. Choose from {topological_dimension.keys()}"
+            )
 
         if cell_type.startswith("polyhedron"):
             self.dim = 3
@@ -180,7 +182,8 @@ class Mesh:
                     raise ValueError(
                         "Cell data must be a list of lists "
                         + f"corresponding to each cell type. "
-                        + f"Type '{type(data[k])}' is not list.")
+                        + f"Type '{type(data[k])}' is not list."
+                    )
 
             if len(data) != len(cells):
                 raise ValueError(

--- a/src/meshio/_vtk_common.py
+++ b/src/meshio/_vtk_common.py
@@ -171,7 +171,7 @@ def vtk_cells_from_data(connectivity, offsets, types, cell_data_raw):
                 new_order = np.arange(n, dtype=offsets.dtype)
             new_order -= n
 
-            indices = np.add.outer(offsets[start:end], new_order)
+            indices = np.add.outer(offsets[start:end], new_order).astype(int)
             cells.append(CellBlock(meshio_type, connectivity[indices]))
             for name, d in cell_data_raw.items():
                 if name not in cell_data:

--- a/src/meshio/mtc/_mtc.py
+++ b/src/meshio/mtc/_mtc.py
@@ -179,9 +179,9 @@ def write(filename, mesh, dimension=None, precision: int = 17):
         line = lin[uniq_idx][uniq_cnt == 1]
 
     # Detecting used nodes
-    used_elems = np.unique(np.concatenate((tetra.flatten(), triangle.flatten())))  # sorted
+    used_nodes = np.unique(np.concatenate((tetra.flatten(), triangle.flatten())))  # sorted
     bools_keep = np.zeros(len(points), dtype=bool)
-    bools_keep[used_elems] = True
+    bools_keep[used_nodes] = True
 
     # Deleting unused nodes and reindexing
     points = points[bools_keep]

--- a/src/meshio/vtu/__init__.py
+++ b/src/meshio/vtu/__init__.py
@@ -1,3 +1,3 @@
-from ._vtu import read, write
+from ._vtu import read, write, check_data_format
 
 __all__ = ["read", "write"]

--- a/src/meshio/vtu/_vtu.py
+++ b/src/meshio/vtu/_vtu.py
@@ -862,7 +862,7 @@ def write(filename, mesh, binary=True, compression="zlib", header_type=None):
                     con += unique_nodes
                     num_nodes_per_cell.append(len(unique_nodes))
 
-            connectivity = np.array(con)
+            connectivity = np.array(con, dtype=np.int32)
             # offsets = np.hstack(([0], np.cumsum(num_nodes_per_cell)[:-1]))
             offsets = np.cumsum(num_nodes_per_cell)
 
@@ -879,7 +879,7 @@ def write(filename, mesh, binary=True, compression="zlib", header_type=None):
                 if new_order is not None:
                     d = d[:, new_order]
                 connectivity.append(d.flatten())
-            connectivity = np.concatenate(connectivity)
+            connectivity = np.concatenate(connectivity, dtype=np.int32)
 
             # offset (points to the first element of the next cell)
             offsets = [

--- a/src/meshio/xdmf/common.py
+++ b/src/meshio/xdmf/common.py
@@ -22,8 +22,8 @@ dtype_to_format_string = {
     "int64": "%d",
     "uint32": "%d",
     "uint64": "%d",
-    "float32": "%.7e",
-    "float64": "%.16e",
+    "float32": "%.7g",
+    "float64": "%.16g",
 }
 
 

--- a/src/meshio/xdmf/time_series.py
+++ b/src/meshio/xdmf/time_series.py
@@ -370,7 +370,12 @@ class TimeSeriesWriter:
             raise WriteError()
         name = f"data{self.data_counter}"
         self.data_counter += 1
-        self.h5_file.create_dataset(name, data=data)
+        if data.dtype == np.float32 or data.dtype == np.float64:
+            self.h5_file.create_dataset(name, data=data, chunks=True, compression="gzip", shuffle=True, scaleoffset=6)
+        elif data.dtype == np.int32 or data.dtype == np.int64 or data.dtype == np.uint32 or data.dtype == np.uint64:
+            self.h5_file.create_dataset(name, data=data, chunks=True, compression="gzip", shuffle=True, scaleoffset=0)
+        else:
+            self.h5_file.create_dataset(name, data=data, chunks=True, compression="gzip", shuffle=True)
         return os.path.basename(self.h5_filename) + ":/" + name
 
     def points(self, grid, points):

--- a/tools/bash_meshio_rc.sh
+++ b/tools/bash_meshio_rc.sh
@@ -1,0 +1,24 @@
+_meshio_complete() {
+    local cur prev commands
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD - 1]}"
+
+    # Define available subcommands
+    commands="ascii binary compress convert decompress info"
+
+    if [[ ${COMP_CWORD} -eq 1 ]]; then
+        COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
+        return 0
+    fi
+
+    # Autocomplete files for subcommands
+    case "${prev}" in
+    ascii | binary | compress | convert | decompress | info)
+        COMPREPLY=($(compgen -f -- "${cur}"))
+        return 0
+        ;;
+    esac
+}
+
+complete -F _meshio_complete meshio


### PR DESCRIPTION
change vtu ascii writing to be compatible with both cimlib and paraview:

- [x] write ascii vtus that can be read by cimlib for Reprise model
- [x] write ascii vtus that can be read by paraview for visualization

This includes bringing changes to the xml emtree class, because cimlib has the following constraints:

- cimlib reads Points only if  x,y,z coords are all written in a single line each (meshio writes une coord per line)
- cimlib reads Points only if no `Name="Points"` keyword is passed in DataArray header
- cimlib reads Connectivities only if c1,c2,c3(,c4) are all passed in a single line each (meshio writes one connectivity component per line)
- paraview reads Connectivities only if no `NumberOfComponents` keyword is passed in DataArray header